### PR TITLE
Pass --disable-factory only to gnome-terminal version <3.8

### DIFF
--- a/rpdb2.py
+++ b/rpdb2.py
@@ -1773,6 +1773,8 @@ def as_bytes(s, encoding = 'utf-8', fstrict = True):
 PYTHON_TAB_WIDTH = 4
 
 GNOME_DEFAULT_TERM = 'gnome-terminal'
+GNOME_DEFAULT_TERM_BEFORE_3_8 = 'gnome-terminal --disable-factory'
+GNOME_DEFAULT_TERM_BEFORE_3_8_CHECK_FILE = "/../share/gnome-terminal/profile-manager.ui" #this glade-related file present for only gnome terminal versions 2.24-3.6
 NT_DEBUG = 'nt_debug'
 SCREEN = 'screen'
 MAC = 'mac'
@@ -1793,7 +1795,8 @@ osSpawn = {
     NT_DEBUG: 'start "rpdb2 - Version ' + get_version() + ' - Debuggee Console" cmd.exe /K ""%(exec)s" %(options)s"',
     POSIX: "%(term)s -e %(shell)s -c '%(exec)s %(options)s; %(shell)s' &",
     'Terminal': "Terminal --disable-server -x %(shell)s -c '%(exec)s %(options)s; %(shell)s' &",
-    GNOME_DEFAULT_TERM: "gnome-terminal --disable-factory -x %(shell)s -c '%(exec)s %(options)s; %(shell)s' &",
+    GNOME_DEFAULT_TERM_BEFORE_3_8: "gnome-terminal --disable-factory -x %(shell)s -c '%(exec)s %(options)s; %(shell)s' &",
+    GNOME_DEFAULT_TERM: "gnome-terminal -x %(shell)s -c '%(exec)s %(options)s; %(shell)s' &",
     MAC: '%(exec)s %(options)s',
     DARWIN: '%(exec)s %(options)s',
     SCREEN: 'screen -t debuggee_console %(exec)s %(options)s'
@@ -3532,8 +3535,14 @@ def CalcTerminalCommand():
             return term
 
     elif IsPrefixInEnviron(GNOME_PREFIX):
-        if IsFileInPath(GNOME_DEFAULT_TERM):
-            return GNOME_DEFAULT_TERM
+        try:
+            gnome_terminal_path = FindFile(GNOME_DEFAULT_TERM)
+            if gnome_terminal_path:
+                if myisfile(os.path.dirname(gnome_terminal_path) + GNOME_DEFAULT_TERM_BEFORE_3_8_CHECK_FILE):
+                    return GNOME_DEFAULT_TERM_BEFORE_3_8
+                return GNOME_DEFAULT_TERM
+        except IOError:
+            pass
 
     if IsFileInPath(XTERM):
         return XTERM


### PR DESCRIPTION
Fixes "Silently fails to open terminal with gnome-terminal >= 3.8" problem.
https://github.com/galkinvv/winpdb/issues/1
This option was required for gnome-terminal <3.6 to keep environment vars.
It was removed in 3.8 and raises error with later versions.
Fortunately it is not needed in later versions: environment is always kept.
There is no obvious stable & documented way to determine version
of gnome-terminal. So just check the presence of a file that was used by
versions 2.24-3.6. This slightly breaks old (pre Sep2008)
gnome-terminal <2.24 by not passing environment vars to the launched script