### PR TITLE
Fix rpdb2 when COLORTERM environment variable is set to 'yes'

### DIFF
--- a/rpdb2.py
+++ b/rpdb2.py
@@ -3526,7 +3526,7 @@ def CalcTerminalCommand():
 
     if COLORTERM in os.environ:
         term = os.environ[COLORTERM]
-        if IsFileInPath(term):
+        if term != 'yes' and IsFileInPath(term):
             return term
 
     if IsPrefixInEnviron(KDE_PREFIX):


### PR DESCRIPTION
On some systems, the COLORTERM environment variable is set to 'yes'.  When this happens, rpdb2 attempts to use yes as the terminal application.  Since this is a valid binary that is not a terminal application, this will cause rpdb2 to fail to open a terminal.  Avoid this by excluding 'yes' as a
possible value when checking COLORTERM.