### PR TITLE
rpdb _print() to fail gracefully if no sys.__stderr__ provided

### DIFF
--- a/rpdb/utils.py
+++ b/rpdb/utils.py
@@ -123,17 +123,18 @@ def winlower(path):
 
 
 def _print(s, f = sys.stdout, feol = True):
-    s = as_unicode(s)
+    if f is not None:
+        s = as_unicode(s)
 
-    encoding = detect_encoding(f)
+        encoding = detect_encoding(f)
 
-    s = as_bytes(s, encoding, fstrict = False)
-    s = as_string(s, encoding)
+        s = as_bytes(s, encoding, fstrict = False)
+        s = as_string(s, encoding)
 
-    if feol:
-        f.write(s + '\n')
-    else:
-        f.write(s)
+        if feol:
+            f.write(s + '\n')
+        else:
+            f.write(s)
 
 
 def print_exception(t, v, tb, fForce = False):

--- a/rpdb/utils.py
+++ b/rpdb/utils.py
@@ -93,7 +93,7 @@ def print_debug(_str):
 
     str = '%s %s:%d %s %s(): %s' % (s, filename, lineno, threadinfo, name, _str)
 
-    _print(str, sys.__stderr__)
+    _print(str, sys.stderr)
 
 
 def print_debug_exception(fForce = False):


### PR DESCRIPTION
As described in the commit messages, make rpdb usable also for implementations where `sys.__stderr__` is `None`.

In case of comments, please do not hesitate to note them here - I am open to further suggestions.